### PR TITLE
Simplify sentence highlighting logic

### DIFF
--- a/src/SpokenSentence.jsx
+++ b/src/SpokenSentence.jsx
@@ -8,12 +8,10 @@ const Container = styled.p({
   fontSize: '2rem',
 });
 
-export default function SpokenSentence({ prompt, spokenSentence, micState }) {
-  const waiting = '...';
-  const defaultMessage = '문장을 소리내어 말해보세요';
+const waiting = '...';
+const placeholder = '문장을 소리내어 말해보세요';
 
-  const sentence = spokenSentence ?? defaultMessage;
-
+export default function SpokenSentence({ micState, prompt, spokenSentence }) {
   const isInputting = micState !== MicState.OFF;
 
   const highligtedPrompt = (
@@ -22,12 +20,19 @@ export default function SpokenSentence({ prompt, spokenSentence, micState }) {
     </b>
   );
 
-  const [leftPart, rightPart] = sentence.split(prompt);
-  const highligtedSentence = [leftPart, highligtedPrompt, rightPart];
+  const sentence = spokenSentence ?? placeholder;
+
+  const highlightSentence = () => {
+    const [leftPart, rightPart] = sentence.split(prompt);
+
+    return rightPart
+      ? [leftPart, highligtedPrompt, rightPart]
+      : [leftPart];
+  };
 
   return (
     <Container>
-      {isInputting ? waiting : highligtedSentence}
+      {isInputting ? waiting : highlightSentence()}
     </Container>
   );
 }

--- a/src/SpokenSentence.jsx
+++ b/src/SpokenSentence.jsx
@@ -9,19 +9,21 @@ const Container = styled.p({
 });
 
 export default function SpokenSentence({ prompt, spokenSentence, micState }) {
-  const defaultMessage = '문장을 소리내어 말해보세요';
   const waiting = '...';
-
-  const isInputting = micState !== MicState.OFF;
+  const defaultMessage = '문장을 소리내어 말해보세요';
 
   const sentence = spokenSentence ?? defaultMessage;
 
-  const highligtedSentence = sentence.split(prompt)
-    .reduce((previous, current, i) => (
-      i === 0
-        ? [current]
-        : previous.concat(<b style={{ color: 'blue' }}>{prompt}</b>, current)
-    ), []);
+  const isInputting = micState !== MicState.OFF;
+
+  const highligtedPrompt = (
+    <b style={{ color: 'blue' }}>
+      {prompt}
+    </b>
+  );
+
+  const [leftPart, rightPart] = sentence.split(prompt);
+  const highligtedSentence = [leftPart, highligtedPrompt, rightPart];
 
   return (
     <Container>


### PR DESCRIPTION
**What**
Simplify the logic of highlighting the prompt in the spoken sentence.
**Why**
Because splitting sentence with prompt results in array with only 2 elements at most,
Don't need to use reduce.