### PR TITLE
Fix multiple prompts matching bug

### DIFF
--- a/src/SpokenSentence.jsx
+++ b/src/SpokenSentence.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import styled from '@emotion/styled';
 
-import _ from 'lodash';
-
 import MicState from './enums/MicState';
 
 const Container = styled.p({
@@ -25,11 +23,15 @@ export default function SpokenSentence({ micState, prompt, spokenSentence }) {
   const sentence = spokenSentence ?? placeholder;
 
   const highlightSentence = () => {
-    const [leftPart, rightPart] = sentence.split(prompt);
+    const splitted = sentence.split(prompt);
 
-    return _.isString(rightPart)
-      ? [leftPart, highligtedPrompt, rightPart]
-      : [leftPart];
+    if (splitted.length <= 1) {
+      return splitted;
+    }
+
+    return splitted
+      .flatMap((part) => [part, highligtedPrompt])
+      .slice(0, -1);
   };
 
   return (


### PR DESCRIPTION
When spoken sentence contains multiple prompts
they all need to be highlighted

![image](https://user-images.githubusercontent.com/53764714/100459220-75283200-3108-11eb-8b75-c86fba7a1297.png)
