### PR TITLE
Set fonts and colors

### DIFF
--- a/dist/global.css
+++ b/dist/global.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Gamja+Flower&family=Sunflower:wght@300;500;700&display=swap');
 
 * {
   margin: 0;

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -1,0 +1,12 @@
+const colors = {
+  primaryColor: '#1CB0F6',
+  secondaryColor: '#5CC6F9',
+  tertiaryColor: '#33B8F7',
+  normalColor: '#FFF',
+  emphasisColor: 'FFC33F',
+
+  correctColor: 'green',
+  wrongColor: 'red',
+};
+
+export default colors;

--- a/src/styles/fonts.js
+++ b/src/styles/fonts.js
@@ -1,0 +1,6 @@
+const fonts = {
+  titleFont: '"Gamja Flower", cursive',
+  normalFont: '"Sunflower", sans-serif',
+};
+
+export default fonts;


### PR DESCRIPTION
Set common fonts and colors for entire app
We can use fonts and colors in a more organized and meaningful way
by setting commons.

![image](https://user-images.githubusercontent.com/53764714/101192315-3c570280-369e-11eb-80e2-d42ebcbafc66.png)
