### PR TITLE
Delete basename

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,7 +11,7 @@ import App from './App';
 
 ReactDOM.render(
   <Provider store={store}>
-    <BrowserRouter basename="/project-react-2-gringrape">
+    <BrowserRouter>
       <App />
     </BrowserRouter>
   </Provider>,


### PR DESCRIPTION
Due to custom domain, there is no need to use basename for URL